### PR TITLE
Support access modifiers in Swift regexes

### DIFF
--- a/StencilPlugin/Model/TemplateConfig.m
+++ b/StencilPlugin/Model/TemplateConfig.m
@@ -63,10 +63,10 @@
 + (NSOrderedSet *)swiftMapsFromFileAtPath:(NSString *)filePath
 {
   NSMutableOrderedSet *maps = [NSMutableOrderedSet new];
-  [self processFileAtPath:filePath matching:@"^\\s*extension\\s+(\\w+).*" thingType:STCThingTypeSwiftClass maps:maps];
-  [self processFileAtPath:filePath matching:@"^\\s*class\\s+(\\w+).*" thingType:STCThingTypeSwiftClass maps:maps];
-  [self processFileAtPath:filePath matching:@"^\\s*class\\s+(\\w+)\\s*:\\s*(\\w+).*" thingType:STCThingTypeSwiftClass maps:maps];
-  [self processFileAtPath:filePath matching:@"^\\s*protocol\\s+(\\w+)\\s*:\\s*(\\w+).*" thingType:STCThingTypeSwiftProtocol maps:maps];
+  [self processFileAtPath:filePath matching:@"^[@objc|public|private|internal]*\\s*extension\\s+(\\w+).*" thingType:STCThingTypeSwiftClass maps:maps];
+  [self processFileAtPath:filePath matching:@"^[@objc|public|private|internal]*\\s*class\\s+(\\w+).*" thingType:STCThingTypeSwiftClass maps:maps];
+  [self processFileAtPath:filePath matching:@"^[@objc|public|private|internal]*\\s*class\\s+(\\w+)\\s*:\\s*(\\w+).*" thingType:STCThingTypeSwiftClass maps:maps];
+  [self processFileAtPath:filePath matching:@"^[@objc|public|private|internal]*\\s*protocol\\s+(\\w+)\\s*:\\s*(\\w+).*" thingType:STCThingTypeSwiftProtocol maps:maps];
   return maps.copy;
 }
 

--- a/StencilPlugin/Model/TemplateConfig.m
+++ b/StencilPlugin/Model/TemplateConfig.m
@@ -62,11 +62,14 @@
 
 + (NSOrderedSet *)swiftMapsFromFileAtPath:(NSString *)filePath
 {
+  NSString *objcPrefix = @"(?:@objc(?:\\s*\\(\\s*\\w+\\s*\\))?)?";
+  NSString *accessPrefix = @"(?:public|private|internal)?";
+    
   NSMutableOrderedSet *maps = [NSMutableOrderedSet new];
-  [self processFileAtPath:filePath matching:@"^[@objc|public|private|internal]*\\s*extension\\s+(\\w+).*" thingType:STCThingTypeSwiftClass maps:maps];
-  [self processFileAtPath:filePath matching:@"^[@objc|public|private|internal]*\\s*class\\s+(\\w+).*" thingType:STCThingTypeSwiftClass maps:maps];
-  [self processFileAtPath:filePath matching:@"^[@objc|public|private|internal]*\\s*class\\s+(\\w+)\\s*:\\s*(\\w+).*" thingType:STCThingTypeSwiftClass maps:maps];
-  [self processFileAtPath:filePath matching:@"^[@objc|public|private|internal]*\\s*protocol\\s+(\\w+)\\s*:\\s*(\\w+).*" thingType:STCThingTypeSwiftProtocol maps:maps];
+  [self processFileAtPath:filePath matching:[NSString stringWithFormat:@"^\\s*%@\\s*%@\\s*extension\\s+(\\w+).*", objcPrefix, accessPrefix] thingType:STCThingTypeSwiftClass maps:maps];
+  [self processFileAtPath:filePath matching:[NSString stringWithFormat:@"^\\s*%@\\s*%@\\s*class\\s+(\\w+).*", objcPrefix, accessPrefix] thingType:STCThingTypeSwiftClass maps:maps];
+  [self processFileAtPath:filePath matching:[NSString stringWithFormat:@"^\\s*%@\\s*%@\\s*class\\s+(\\w+)\\s*:\\s*(\\w+).*", objcPrefix, accessPrefix] thingType:STCThingTypeSwiftClass maps:maps];
+  [self processFileAtPath:filePath matching:[NSString stringWithFormat:@"^\\s*%@\\s*%@\\s*protocol\\s+(\\w+)\\s*:\\s*(\\w+).*", objcPrefix, accessPrefix] thingType:STCThingTypeSwiftProtocol maps:maps];
   return maps.copy;
 }
 


### PR DESCRIPTION
The class detection mechanism would fail in cases where an access modifier was used before the class definition.

I debated using "\w*" instead of naming each possible modifier, but I feel that the latter approach is safer.
